### PR TITLE
feat: add support for nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1690473371,
+        "narHash": "sha256-T7IhvlcM/QiKyOzkeGhuM3ohGHq21EvMa6A3qY8bMmc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bdddb46f4b058465ad53134d4a118671f9956662",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Install and debug iOS apps from the command line. Designed to work on un-jailbroken devices";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+  outputs = { self, nixpkgs }:
+    let
+      # The set of systems to provide outputs for
+      allSystems = [ "x86_64-darwin" "aarch64-darwin" ];
+
+      # A function that provides a system-specific Nixpkgs for the desired systems
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+      version = "1.12.2";
+    in
+    {
+      packages = forAllSystems ({ pkgs }: {
+        default = with pkgs;  stdenvNoCC.mkDerivation {
+          pname = "ios-deploy";
+          inherit version;
+          src = ./.;
+          nativeBuildInputs = [ rsync ];
+          buildPhase = ''
+            LD=$CC
+            tmp=$(mktemp -d)
+            ln -s /usr/bin/xcodebuild $tmp
+            export PATH="$PATH:$tmp"
+            xcodebuild -configuration Release SYMROOT=build OBJROOT=$tmp
+          '';
+          checkPhase = ''
+            xcodebuild test -scheme ios-deploy-tests -configuration Release SYMROOT=build
+          '';
+          installPhase = ''
+            install -D build/Release/ios-deploy $out/bin/ios-deploy
+          '';
+          meta = {
+            platforms = lib.platforms.darwin;
+            description = "Install and debug iOS apps from the command line. Designed to work on un-jailbroken devices";
+            license = lib.licenses.gpl3;
+          };
+        };
+      });
+    };
+}


### PR DESCRIPTION
it takes the actual derivation on nixpkgs, update the version, and use it as a flake